### PR TITLE
Fix error caused by A1111's update

### DIFF
--- a/scripts/lora_block_weight.py
+++ b/scripts/lora_block_weight.py
@@ -707,6 +707,10 @@ def load_lora(name, filename,lwei):
             elif lora_key == "lora_down.weight":
                 lora_module.down_model = module
                 lora_module.dim = weight.shape[0]
+                lora_module.down = FakeModule(
+                    lora_module.down_model.weight,
+                    lora_module.inference
+                )
         elif lora_key in HADA_KEY:
             if type(lora_module) != LoraHadaModule:
                 alpha = lora_module.alpha

--- a/scripts/lora_block_weight.py
+++ b/scripts/lora_block_weight.py
@@ -394,7 +394,7 @@ def loradealer(p,lratios):
         if called.items[2] in lratios or called.items[2].count(",") ==16 or called.items[2].count(",") ==25:
             lorans.append(called.items[0])
             wei = lratios[called.items[2]] if called.items[2] in lratios else called.items[2] 
-            multiple = called.items[1]
+            multiple = float(called.items[1])
             ratios = [w.strip() for w in wei.split(",")]
             for i,r in enumerate(ratios):
                 if r =="R":
@@ -406,7 +406,7 @@ def loradealer(p,lratios):
                     ratios[i] = getinheritedweight(base, r)
                 else:
                     ratios[i] = float(r)
-            print(f"LoRA Block weight :{called.items[0]}: {ratios}")
+            print(f"LoRA Block weight: {called.items[0]}: {[x * multiple for x in ratios]}")
             if len(ratios)==17:
                 ratios = [ratios[0]] + [1] + ratios[1:3]+ [1] + ratios[3:5]+[1] + ratios[5:7]+[1,1,1] + [ratios[7]] + [1,1,1] + ratios[8:]
             lorars.append(ratios)


### PR DESCRIPTION
Per https://github.com/AUTOMATIC1111/stable-diffusion-webui/commit/80b26d2a69617b75d2d01c1e6b7d11445815ed4d, A1111 has changed the way how LoRA apply weights.