### PR TITLE
Honor IGNORE_CMD_ARGS_ERRORS environment variable

### DIFF
--- a/scripts/lora_block_weight.py
+++ b/scripts/lora_block_weight.py
@@ -137,7 +137,10 @@ class Script(modules.scripts.Script):
         ratiostags = [k for k in lratios.keys()]
         ratiostags = ",".join(ratiostags)
 
-        args = cmd_args.parser.parse_args()
+        if os.environ.get('IGNORE_CMD_ARGS_ERRORS', None) is None:
+            args = cmd_args.parser.parse_args()
+        else:
+            args, _ = cmd_args.parser.parse_known_args()
         if args.api:
             register()
 


### PR DESCRIPTION
Currently setting the a1111 environment variable IGNORE_CMD_ARGS_ERRORS leads to an error in lora-block-weight. This change fixes that.

It's the same logic as in the original a1111 module:
https://github.com/AUTOMATIC1111/stable-diffusion-webui/blob/23c947ab0374220c39ac54fc00afcb74e809dd95/modules/shared.py#L33-L36