### PR TITLE
Fix hako-mikan/sd-webui-lora-block-weight#111

### DIFF
--- a/scripts/lora_block_weight.py
+++ b/scripts/lora_block_weight.py
@@ -558,9 +558,9 @@ def loradealer(self, prompts,lratios,elementals, extra_network_data = None):
             multipliers.append(multiple)
             if len(called.items) <3:
                 continue
-            lorans.append(called.items[0])
             weights = syntaxdealer(called.items,"lbw=",None,2)
             if weights in lratios or any(weights.count(",") == x - 1 for x in BLOCKNUMS):
+                lorans.append(called.items[0])
                 wei = lratios[weights] if weights in lratios else weights
                 ratios = [w.strip() for w in wei.split(",")]
                 for i,r in enumerate(ratios):


### PR DESCRIPTION
`load_loras_blocks` iterates lorans and it requires weights. If there are no weights then there is no reason to append to lorans, in that case just skip the network and let webui handle the te and unet. This fixes an index out of range error when there's multiple networks, and one or more loras define both the TE and UNET but no weights, and at least one lora defines weights from Lora Block Weight.