### PR TITLE
feat: GLora support

### DIFF
--- a/scripts/lora_block_weight.py
+++ b/scripts/lora_block_weight.py
@@ -906,6 +906,7 @@ LORAANDSOON = {
     "LoraKronModule" : "w1",
     "LycoKronModule" : "w1",
     "NetworkModuleLokr": "w1",
+    "NetworkModuleGLora": "w1a",
 }
 
 def hyphener(t):


### PR DESCRIPTION
GLora support is merged into A1111 dev - this PR adds NetworkModuleGLora to LORAANDSOON to support modifying block weight for GLora networks. 

When block weight is changed, I get these debug messages complaining about `..._resblocks_xx_attn` and `_skip_connection` layers in the command line, but it otherwise appears to be working:

```
2023-10-28 14:15:28 DEBUG [root] Network sdxl_gloratest_in_LBW_0.727 layer 1_model_transformer_resblocks_31_attn: The size of tensor a (1280) must match the size of tensor b (3840) at non-singleton dimension 0

2023-10-28 14:15:28 DEBUG [root] Network sdxl_gloratest_in_LBW_0.727 layer diffusion_model_input_blocks_4_0_skip_connection: The size of tensor a (8) must match the size of tensor b (320) at non-singleton dimension 1
```