### PR TITLE
support new forge

### DIFF
--- a/scripts/lora_block_weight.py
+++ b/scripts/lora_block_weight.py
@@ -1137,40 +1137,41 @@ def lbw(lora,lwei,elemental):
 LORAS = ["lora", "loha", "lokr"]
 
 def lbwf(mt, mu, lwei, elemental, starts):
+    errormodules = []
+
     after_applying_unet_lora_patches = shared.sd_model.forge_objects_after_applying_lora.unet.lora_patches
-    unet_hashes = []
-    for hash, lora_patches in after_applying_unet_lora_patches.items():
-        lbw_key = ",".join([str(mu[0])] + [str(int(w) if type(w) is int or w.is_integer() else float(w)) for w in lwei[0]])
-        unet_hashes.append((hash, (hash[0], lbw_key, *hash[2:])))
-    for hash, new_hash in unet_hashes:
+    hashes = []
+    for m, hash in zip(mu, after_applying_unet_lora_patches.keys()):
+        lbw_key = ",".join([str(m)] + [str(int(w) if type(w) is int or w.is_integer() else float(w)) for w in lwei[0]])
+        hashes.append((hash, (hash[0], lbw_key, *hash[2:])))
+    for hash, new_hash in hashes:
         after_applying_unet_lora_patches[new_hash] = after_applying_unet_lora_patches[hash]
         del after_applying_unet_lora_patches[hash]
 
-    for hash, lora_patches in after_applying_unet_lora_patches.items():
+    for m, l, e, s, (hash, lora_patches) in zip(mu, lwei, elemental, starts, after_applying_unet_lora_patches.items()):
         for key, vals in lora_patches.items():
             n_vals = []
-            errormodules = []
             lvs = [v for v in vals if v[1][0] in LORAS]
-            for v, m, l, e ,s in zip(lvs, mu, lwei, elemental, starts):
+            for v in lvs:
                 ratio, errormodule = ratiodealer(key.replace(".","_"), l, e)
                 n_vals.append([ratio * m if s is None else 0, *v[1:]])
                 if errormodule:errormodules.append(errormodule)
             lora_patches[key] = n_vals
 
     after_applying_clip_lora_patches = shared.sd_model.forge_objects_after_applying_lora.clip.patcher.lora_patches
-    unet_hashes = []
-    for hash, lora_patches in after_applying_clip_lora_patches.items():
-        lbw_key = ",".join([str(mt[0])] + [str(int(w) if type(w) is int or w.is_integer() else float(w)) for w in lwei[0]])
-        unet_hashes.append((hash, (hash[0], lbw_key, *hash[2:])))
-    for hash, new_hash in unet_hashes:
+    hashes = []
+    for m, hash in zip(mt, after_applying_clip_lora_patches.keys()):
+        lbw_key = ",".join([str(m)] + [str(int(w) if type(w) is int or w.is_integer() else float(w)) for w in lwei[0]])
+        hashes.append((hash, (hash[0], lbw_key, *hash[2:])))
+    for hash, new_hash in hashes:
         after_applying_clip_lora_patches[new_hash] = after_applying_clip_lora_patches[hash]
         del after_applying_clip_lora_patches[hash]
 
-    for hash, lora_patches in after_applying_clip_lora_patches.items():
+    for m, l, e, s, (hash, lora_patches) in zip(mu, lwei, elemental, starts, after_applying_clip_lora_patches.items()):
         for key, vals in lora_patches.items():
             n_vals = []
             lvs = [v for v in vals if v[1][0] in LORAS]
-            for v, m, l, e in zip(lvs, mt, lwei, elemental):
+            for v in lvs:
                 ratio, errormodule = ratiodealer(key.replace(".","_"), l, e)
                 n_vals.append([ratio * m, *v[1:]])
                 if errormodule:errormodules.append(errormodule)

--- a/scripts/lora_block_weight.py
+++ b/scripts/lora_block_weight.py
@@ -1166,7 +1166,7 @@ def lbwf(after_applying_lora_patches, ms, lwei, elements, starts, func_ratio):
             lora_patches[key] = n_vals
             # print("[DEBUG]", hash[0], *[n_val[0] for n_val in n_vals])
 
-        lbw_key = ",".join([str(m)] + [str(int(w) if type(w) is int or w.is_integer() else float(w)) for w in lwei[0]])
+        lbw_key = ",".join([str(m)] + [str(int(w) if type(w) is int or w.is_integer() else float(w)) for w in l])
         new_hash = (hash[0], lbw_key, *hash[2:])
 
         after_applying_lora_patches[new_hash] = after_applying_lora_patches[hash]

--- a/scripts/lora_block_weight.py
+++ b/scripts/lora_block_weight.py
@@ -1137,7 +1137,16 @@ def lbw(lora,lwei,elemental):
 LORAS = ["lora", "loha", "lokr"]
 
 def lbwf(mt, mu, lwei, elemental, starts):
-    for lora_patches in shared.sd_model.forge_objects_after_applying_lora.unet.lora_patches.values():
+    after_applying_unet_lora_patches = shared.sd_model.forge_objects_after_applying_lora.unet.lora_patches
+    unet_hashes = []
+    for hash, lora_patches in after_applying_unet_lora_patches.items():
+        lbw_key = ",".join([str(mu[0])] + [str(int(w) if type(w) is int or w.is_integer() else float(w)) for w in lwei[0]])
+        unet_hashes.append((hash, (hash[0], lbw_key, *hash[2:])))
+    for hash, new_hash in unet_hashes:
+        after_applying_unet_lora_patches[new_hash] = after_applying_unet_lora_patches[hash]
+        del after_applying_unet_lora_patches[hash]
+
+    for hash, lora_patches in after_applying_unet_lora_patches.items():
         for key, vals in lora_patches.items():
             n_vals = []
             errormodules = []
@@ -1148,7 +1157,16 @@ def lbwf(mt, mu, lwei, elemental, starts):
                 if errormodule:errormodules.append(errormodule)
             lora_patches[key] = n_vals
 
-    for lora_patches in shared.sd_model.forge_objects_after_applying_lora.clip.patcher.lora_patches.values():
+    after_applying_clip_lora_patches = shared.sd_model.forge_objects_after_applying_lora.clip.patcher.lora_patches
+    unet_hashes = []
+    for hash, lora_patches in after_applying_clip_lora_patches.items():
+        lbw_key = ",".join([str(mt[0])] + [str(int(w) if type(w) is int or w.is_integer() else float(w)) for w in lwei[0]])
+        unet_hashes.append((hash, (hash[0], lbw_key, *hash[2:])))
+    for hash, new_hash in unet_hashes:
+        after_applying_clip_lora_patches[new_hash] = after_applying_clip_lora_patches[hash]
+        del after_applying_clip_lora_patches[hash]
+
+    for hash, lora_patches in after_applying_clip_lora_patches.items():
         for key, vals in lora_patches.items():
             n_vals = []
             lvs = [v for v in vals if v[1][0] in LORAS]


### PR DESCRIPTION
issue #167

new forgeで動作するように修正しました。
※8/29に更新されたバージョン[8e4a6fc]である必要があるようです。
lbwf関数は大きめの変更が入っていますが、それ以外はロジックの変更は無くA1111と互換性がなくなってしまった関数の変更のみ行っています。

I've modified it to work with new forge.
*Note: It must be the version [8e4a6fc] that was pushed on August 29.
The lbwf function has undergone significant changes, but aside from that, the main logic hasn't been altered, and only the functions that became incompatible with A1111 have been adjusted.