### PR TITLE
Fixed bug where LoRA stopped working when HiRes was enabled.

### DIFF
--- a/scripts/lora_block_weight.py
+++ b/scripts/lora_block_weight.py
@@ -1170,7 +1170,8 @@ def lbwf(after_applying_lora_patches, ms, lwei, elements, starts, func_ratio):
         new_hash = (hash[0], lbw_key, *hash[2:])
 
         after_applying_lora_patches[new_hash] = after_applying_lora_patches[hash]
-        del after_applying_lora_patches[hash]
+        if new_hash != hash:
+            del after_applying_lora_patches[hash]
 
     if len(errormodules) > 0:
         print("Unknown modules:", errormodules)

--- a/scripts/lora_block_weight.py
+++ b/scripts/lora_block_weight.py
@@ -4,6 +4,7 @@ import os
 import gc
 import re
 import sys
+import copy
 import torch
 import shutil
 import math
@@ -1143,6 +1144,7 @@ def lbw(lora,lwei,elemental):
 LORAS = ["lora", "loha", "lokr"]
 
 def lbwf(after_applying_lora_patches, ms, lwei, elements, starts, func_ratio):
+    after_applying_lora_patches = copy.deepcopy(after_applying_lora_patches)
     errormodules = []
     dict_lora_patches = dict(after_applying_lora_patches.items())
     for m, l, e, s, hash in zip(ms, lwei, elements, starts, list(shared.sd_model.forge_objects.unet.lora_patches.keys())):

--- a/scripts/lora_block_weight.py
+++ b/scripts/lora_block_weight.py
@@ -4,7 +4,6 @@ import os
 import gc
 import re
 import sys
-import copy
 import torch
 import shutil
 import math
@@ -1144,7 +1143,6 @@ def lbw(lora,lwei,elemental):
 LORAS = ["lora", "loha", "lokr"]
 
 def lbwf(after_applying_lora_patches, ms, lwei, elements, starts, func_ratio):
-    after_applying_lora_patches = copy.deepcopy(after_applying_lora_patches)
     errormodules = []
     dict_lora_patches = dict(after_applying_lora_patches.items())
     for m, l, e, s, hash in zip(ms, lwei, elements, starts, list(shared.sd_model.forge_objects.unet.lora_patches.keys())):


### PR DESCRIPTION
#167 

Hiresが有効のときLoRAが効かなくなるバグを修正しました。
※新しく作り直したlbwf関数がLoRAの辞書に対して破壊的な作りになっていたことが原因だったのでdeepcopyを使用し呼び出し元に影響がないようにしました。

Fixed a bug where LoRA would stop working when Hires was enabled.
Note: The issue was caused by the newly reworked lbwf function destructively modifying the LoRA dictionary, so I used deepcopy to prevent any impact on the original data.