### PR TITLE
Support forge

### DIFF
--- a/scripts/lora_block_weight.py
+++ b/scripts/lora_block_weight.py
@@ -973,12 +973,10 @@ def load_loras_blocks(self, names, lwei,te,unet,elements,ltype = "lora", starts 
     
     elif "forge" == ltype:
         lora_patches = shared.sd_model.forge_objects_after_applying_lora.unet.lora_patches
-        lbwf(lora_patches, unet, lwei, elements, starts,
-                lambda r, m, s: r * m if s is None else 0)
+        lbwf(lora_patches, unet, lwei, elements, starts)
 
         lora_patches = shared.sd_model.forge_objects_after_applying_lora.clip.patcher.lora_patches
-        lbwf(lora_patches, te, lwei, elements, starts,
-                lambda r, m, _: r * m)
+        lbwf(lora_patches, te, lwei, elements, starts)
 
     try:
         import lora_ctl_network as ctl
@@ -1142,7 +1140,7 @@ def lbw(lora,lwei,elemental):
 
 LORAS = ["lora", "loha", "lokr"]
 
-def lbwf(after_applying_lora_patches, ms, lwei, elements, starts, func_ratio):
+def lbwf(after_applying_lora_patches, ms, lwei, elements, starts):
     errormodules = []
     dict_lora_patches = dict(after_applying_lora_patches.items())
     for m, l, e, s, hash in zip(ms, lwei, elements, starts, list(shared.sd_model.forge_objects.unet.lora_patches.keys())):
@@ -1160,7 +1158,7 @@ def lbwf(after_applying_lora_patches, ms, lwei, elements, starts, func_ratio):
             lvs = [v for v in vals if v[1][0] in LORAS]
             for v in lvs:
                 ratio, errormodule = ratiodealer(key.replace(".","_"), l, e)
-                n_vals.append([func_ratio(ratio, m, s), *v[1:]])
+                n_vals.append((ratio * m if s is None or s == 0 else 0, *v[1:]))
                 if errormodule:
                     errormodules.append(errormodule)
             lora_patches[key] = n_vals

--- a/scripts/lora_block_weight.py
+++ b/scripts/lora_block_weight.py
@@ -12,6 +12,7 @@ import numpy as np
 import gradio as gr
 import os.path
 import random
+import time
 from pprint import pprint
 import modules.ui
 import modules.scripts as scripts
@@ -440,32 +441,52 @@ class Script(modules.scripts.Script):
                         sets.append(key)
 
         if forge and self.active:
-            if params.sampling_step in self.startsf:
-                shared.sd_model.forge_objects.unet.forge_unpatch_model(target_device=devices.device)
-                for m, l, e, s, lora_patches in zip(self.uf, self.lf, self.ef, self.startsf, list(shared.sd_model.forge_objects.unet.lora_patches.values())):
-                    for key, vals in lora_patches.items():
+            def apply_weight(stop = False):
+                if not stop:
+                    flag_step = self.startsf
+                else:
+                    flag_step = self.stopsf
+
+                lora_patches = shared.sd_model.forge_objects.unet.lora_patches
+                refresh_keys = {}
+                for m, l, e, s, (patch_key, lora_patch) in zip(self.uf, self.lf, self.ef, flag_step, list(lora_patches.items())):
+                    refresh = False
+                    for key, vals in lora_patch.items():
                         n_vals = []
                         for v in [v for v in vals if v[1][0] in LORAS]:
                             if s is not None and s == params.sampling_step:
-                                ratio, _ = ratiodealer(key.replace(".","_"), l, e)
-                                n_vals.append((ratio * m, *v[1:]))
+                                if not stop:
+                                    ratio, _ = ratiodealer(key.replace(".","_"), l, e)
+                                    n_vals.append((ratio * m, *v[1:]))
+                                else:
+                                    n_vals.append((0, *v[1:]))
+                                refresh = True
                             else:
                                 n_vals.append(v)
-                        lora_patches[key] = n_vals
-                shared.sd_model.forge_objects.unet.forge_patch_model()
+                        lora_patch[key] = n_vals
+                    if refresh:
+                        refresh_keys[patch_key] = None
+
+                if len(refresh_keys):
+                    for refresh_key in list(refresh_keys.keys()):
+                        patch = lora_patches[refresh_key]
+                        del lora_patches[refresh_key]
+                        new_key = (f"{refresh_key[0]}_{str(time.time())}", *refresh_key[1:])
+                        refresh_keys[refresh_key] = new_key
+                        lora_patches[new_key] = patch
+
+                    shared.sd_model.forge_objects.unet.refresh_loras()
+
+                    for refresh_key, new_key in list(refresh_keys.items()):
+                        patch = lora_patches[new_key]
+                        del lora_patches[new_key]
+                        lora_patches[refresh_key] = patch
+
+            if params.sampling_step in self.startsf:
+                apply_weight()
 
             if params.sampling_step in self.stopsf:
-                shared.sd_model.forge_objects.unet.forge_unpatch_model(target_device=devices.device)
-                for m, l, e, s, lora_patches in zip(self.uf, self.lf, self.ef, self.stopsf, list(shared.sd_model.forge_objects.unet.lora_patches.values())):
-                    for key, vals in lora_patches.items():
-                        n_vals = []
-                        for v in [v for v in vals if v[1][0] in LORAS]:
-                            if s is not None and s == params.sampling_step:
-                                n_vals.append((0, *v[1:]))
-                            else:
-                                n_vals.append(v)
-                        lora_patches[key] = n_vals
-                shared.sd_model.forge_objects.unet.forge_patch_model()
+                apply_weight(stop=True)
 
         elif self.active:
             if self.starts and params.sampling_step == 0:


### PR DESCRIPTION
#172

start/stop指定が効かない問題を修正しました。

1. 原因
  forge対応前[4d94d247a6]: shared.sd_model.forge_objects.unet.**patch_model**()
  forge対応後[e11116ce3a]: shared.sd_model.forge_objects.unet.**forge_patch_model**()
  **patch_model**関数が未定義となったためそれの代替と思われる**forge_patch_model**関数に変更したのですが
  この関数の呼び出しでは描画のWeightに影響がありませんでした。

2. 修正内容
  start/stop指定により有効/無効が切り替わったLoRAがある場合、以下関数を呼び出すようにしました。
  shared.sd_model.forge_objects.unet.refresh_loras()

3. 問題点
  気のせいかもしれませんが、start/stopの動作がA1111で動作していたときより少し遅くなったような気がします。
  廃止される前のpatch_model関数を再現するのが一番良いと思いつつも
  forgeの作りの理解度が足りずrefresh_loras関数を呼び出して対応することで手一杯でした。。。

4. その他
  以下の式が誤っていたので修正しました。
  https://github.com/hako-mikan/sd-webui-lora-block-weight/blob/4d94d247a6e6d77c11c2d536a5138a54f4d9e500/scripts/lora_block_weight.py#L1155C28-L1155C45

忙しい中いつも確認ありがとうございます🙇‍♂️


I have fixed the issue where the start/stop specification was not working.

1. Cause of the issue:
  Before Forge support [4d94d247a6]: shared.sd_model.forge_objects.unet.**patch_model**()
  After Forge support [e11116ce3a]: shared.sd_model.forge_objects.unet.**forge_patch_model**()
  Since the **patch_model** function became undefined, I replaced it with what seemed to be the alternative **forge_patch_model** function. However, calling this function did not affect the rendering weights.

2. Fix:
  When there is a LoRA that gets enabled/disabled based on the start/stop specification, I modified it to call the following function:
  shared.sd_model.forge_objects.unet.refresh_loras()

3. Issue:
  This might just be my imagination, but the start/stop behavior seems a bit slower than it was when running on A1111. Ideally, it would be best to recreate the deprecated patch_model function, but due to my limited understanding of Forge's architecture, I could only address the issue by calling the refresh_loras() function.

4. Other:
  I also fixed an error in the following formula:
  https://github.com/hako-mikan/sd-webui-lora-block-weight/blob/4d94d247a6e6d77c11c2d536a5138a54f4d9e500/scripts/lora_block_weight.py#L1155C28-L1155C45